### PR TITLE
Clear state after transition

### DIFF
--- a/src/BlazorTransitionableRoute/TransitionableRoutePrimary.razor
+++ b/src/BlazorTransitionableRoute/TransitionableRoutePrimary.razor
@@ -1,3 +1,6 @@
 ﻿<CascadingValue Value="Transition">
-    @ChildContent
+    @if (!isHidden)
+    {
+        @ChildContent
+    }
 </CascadingValue>

--- a/src/BlazorTransitionableRoute/TransitionableRoutePrimary.razor.cs
+++ b/src/BlazorTransitionableRoute/TransitionableRoutePrimary.razor.cs
@@ -41,6 +41,7 @@ namespace BlazorTransitionableRoute
         internal bool invokesStateChanged = true;
 
         private bool isActive = true;
+        internal bool isHidden = false;
         private RouteData lastRouteData;
         public TransitionableRoutePrimary()
         {
@@ -93,6 +94,9 @@ namespace BlazorTransitionableRoute
         [Parameter]
         public Transition Transition { get; set; }
 
+        [Parameter]
+        public bool ClearState { get; set; } = false;
+
         [JSInvokable]
         public async Task Navigate(bool backwards)
         {
@@ -105,6 +109,11 @@ namespace BlazorTransitionableRoute
 
             Transition = Transition.Create(routeDateToUse, isActive, backwards, firstRender);
 
+            if (ClearState)
+            {
+                if (isActive) isHidden = false;
+            }
+
             if (invokesStateChanged)
             {
                 StateHasChanged();
@@ -116,6 +125,20 @@ namespace BlazorTransitionableRoute
             await Task.Yield();
 
             await TransitionInvoker.InvokeRouteTransitionAsync(backwards);
+        }
+
+        [JSInvokable]
+        public async Task Hide()
+        {
+            if (ClearState && isActive)
+            {
+                isHidden = true;
+
+                if (invokesStateChanged)
+                {
+                    StateHasChanged();
+                }
+            }
         }
     }
 }

--- a/src/BlazorTransitionableRoute/TransitionableRouteSecondary.razor
+++ b/src/BlazorTransitionableRoute/TransitionableRouteSecondary.razor
@@ -1,7 +1,10 @@
 ﻿@inherits TransitionableRoutePrimary
 
 <CascadingValue Value="Transition">
-    @ChildContent
+    @if (!isHidden)
+    {
+        @ChildContent
+    }
 </CascadingValue>
 
 @code {

--- a/src/BlazorTransitionableRoute/wwwroot/jsInterop.js
+++ b/src/BlazorTransitionableRoute/wwwroot/jsInterop.js
@@ -87,15 +87,16 @@ window.blazorTransitionableRoute = {
             window.addEventListener('back', event => {
                 isBackwards = true;
             });
-
-            document.body.addEventListener("animationend", event => {
-                if (event.target.classList.contains("b-Transitionable-route")) {
-                    window.blazorTransitionableRoute.dotnetHelperPrimary.invokeMethodAsync('Hide');
-                    window.blazorTransitionableRoute.dotnetHelperSecondary.invokeMethodAsync('Hide');
-                }
-            });
+            document.body.addEventListener("webkitAnimationEnd", this.AddAnimationEventsListner);
+            document.body.addEventListener("animationend", this.AddAnimationEventsListner);
         } else {
             window.blazorTransitionableRoute.dotnetHelperSecondary = dotnetHelper;
+        }
+    },
+    AddAnimationEventsListner(e) {
+        if (event.target.classList.contains("b-Transitionable-route")) {
+            window.blazorTransitionableRoute.dotnetHelperPrimary.invokeMethodAsync('Hide');
+            window.blazorTransitionableRoute.dotnetHelperSecondary.invokeMethodAsync('Hide');
         }
     }
 }

--- a/src/BlazorTransitionableRoute/wwwroot/jsInterop.js
+++ b/src/BlazorTransitionableRoute/wwwroot/jsInterop.js
@@ -87,6 +87,13 @@ window.blazorTransitionableRoute = {
             window.addEventListener('back', event => {
                 isBackwards = true;
             });
+
+            document.body.addEventListener("animationend", event => {
+                if (event.target.classList.contains("b-Transitionable-route")) {
+                    window.blazorTransitionableRoute.dotnetHelperPrimary.invokeMethodAsync('Hide');
+                    window.blazorTransitionableRoute.dotnetHelperSecondary.invokeMethodAsync('Hide');
+                }
+            });
         } else {
             window.blazorTransitionableRoute.dotnetHelperSecondary = dotnetHelper;
         }


### PR DESCRIPTION
Provides an optional flag to clear state after transitioning away

Hey big fan of this library, think I have a solution to #2. This allows you to turn on the option to clear the state after the transition has finished. I did this with the "animationend" event which allows me to know when to remove it from the DOM. There are a couple of caveats doing it this way.

1. Can only use transition which are CSS keyframes (CSS animations)
2. If you navigate back to the same page before the animation finished then the state will not change (Works as currently does). I think this is unlikely as most animations will be under .5s. But still an issue to be a aware of.

There are few things which need to be setup for it to work.

app.razor - need to add set 'ClearState= true' on both 'RoutePrimary' and 'RouteSecondary'
```
<Found Context="routeData">
        <LayoutView Layout="@typeof(MainLayout)">
            <TransitionableRoutePrimary RouteData="@routeData" ClearState="true">
                <TransitionableRouteView DefaultLayout="@typeof(MyViewLayout)" />
            </TransitionableRoutePrimary>
            <TransitionableRouteSecondary RouteData="@routeData" ClearState="true">
                <TransitionableRouteView DefaultLayout="@typeof(MyViewLayout)" />
            </TransitionableRouteSecondary>
        </LayoutView>
    </Found>
```

MyViewLayout.razor - You need to add 'b-Transitionable-route' class to the html element doing the transition 
```
@inherits TransitionableLayoutComponent

<div class="transition @transitioningClass b-Transitionable-route">
    @Body
</div>

<style>
    .transition {
        position: absolute;
    }

</style>

@if (!Transition.FirstRender)
{
<style>
    .transition-in {
        opacity: 0;
    }
</style>
}

@code {
    private string transitioningClass => Transition.IntoView ? "transition-in" : "transition-out";
}
```

This is all you need to do for the setup.

This is not a breaking change.